### PR TITLE
Support for Comments

### DIFF
--- a/app/controllers/abstracts.rb
+++ b/app/controllers/abstracts.rb
@@ -65,7 +65,7 @@ module Judy
     post '/abstracts/:abstract_id/scores/?' do
       begin
         content_type 'application/json'
-        @score = Score.upsert(:judge => session[:user], :count => params[:count], :abstract_id => params[:abstract_id])
+        @score = Score.upsert(:judge => session[:user], :count => params[:count], :abstract_id => params[:abstract_id], :comment => params[:comment])
         status 204
       rescue => e
         p e.message

--- a/app/migrations/004_AddCommentToScore.rb
+++ b/app/migrations/004_AddCommentToScore.rb
@@ -1,0 +1,8 @@
+
+Sequel.migration do
+  up do
+    alter_table(:scores) do
+      add_column :comment, String
+    end
+  end
+end

--- a/app/models/abstracts.rb
+++ b/app/models/abstracts.rb
@@ -32,7 +32,7 @@ class Abstract < Sequel::Model
       abstract.values[:total_score] = 0
       @scores.each do |score|
         if score.abstract_id == abstract.id
-          abstract.values[:scores] << { :judge => score.judge, :count => score.count }
+          abstract.values[:scores] << { :judge => score.judge, :count => score.count, :comment => score.comment }
           abstract.values[:total_score] += score.count
         end
       end
@@ -67,6 +67,7 @@ class Abstract < Sequel::Model
       where(:abstracts__event_id => :events__id).first
     @score = Score.filter(:judge => args[:judge], :abstract_id => args[:id]).first
     @abstract[:score] = @score.count if !@score.nil?
+    @abstract[:comment] = @score.comment
     return @abstract
   end
 

--- a/app/models/scores.rb
+++ b/app/models/scores.rb
@@ -22,9 +22,9 @@ class Score < Sequel::Model
   def self.upsert(args)
     @score = Score.filter(:judge => args[:judge], :abstract_id => args[:abstract_id]).first
     if @score.nil?
-      Score.new(:count => args[:count], :judge => args[:judge], :abstract_id => args[:abstract_id]).save
+      Score.new(:count => args[:count], :judge => args[:judge], :abstract_id => args[:abstract_id], :comment => args[:comment]).save
     else
-      @score.update(:count => args[:count]).save
+      @score.update(:count => args[:count], :comment => args[:comment]).save
     end
   end
 

--- a/app/public/css/style.css
+++ b/app/public/css/style.css
@@ -145,10 +145,6 @@ div.abstract {
   margin-bottom: 20px;
   width: 86%;
 }
-.commentbox-title {
-  margin-left: 40px;
-  font-weight: bold;
-}
 
 .slider {
   margin-left: 40px;

--- a/app/public/css/style.css
+++ b/app/public/css/style.css
@@ -79,6 +79,10 @@ ul.abstracts li span.score {
   color: #fff;
 }
 
+ul.abstracts li span.comment {
+  margin-left: 65px;
+}
+
 ul.abstracts li a, ul.events li a {
   font-family: 'Roboto Slab', serif;
   font-weight: normal;
@@ -134,6 +138,16 @@ div.abstract {
 .well.scoring {
   margin-top: 50px;
   padding: 40px 0;
+}
+
+.commentbox {
+  margin-left: 40px;
+  margin-bottom: 20px;
+  width: 86%;
+}
+.commentbox-title {
+  margin-left: 40px;
+  font-weight: bold;
 }
 
 .slider {

--- a/app/views/abstracts/show.erb
+++ b/app/views/abstracts/show.erb
@@ -48,8 +48,7 @@
 
 <div class="well scoring col-xs-12 col-sm-12 col-md-6 col-md-offset-3">
   <form id="score" action="#" method="post" role="form">
-    <span class="commentbox-title">Your Review Comments</span>
-    <textarea name="comment" id="commentbox" class="form-control commentbox" rows="3"><%= abstract[:comment] %></textarea>
+    <textarea name="comment" id="commentbox" class="form-control commentbox" rows="3" placeholder="Review Comments"><%= abstract[:comment] %></textarea>
     <input class="col-xs-3 col-sm-8 col-md-6 col-lg-7" id="scoreSlider" data-slider-id="scoreSlider" type="text" data-slider-min="0" data-slider-max="10" data-slider-step="1" data-slider-value="<%= abstract[:score] || 0 %>"></input>
     <span class="saveScore">
       <div class="btn-group">

--- a/app/views/abstracts/show.erb
+++ b/app/views/abstracts/show.erb
@@ -48,6 +48,8 @@
 
 <div class="well scoring col-xs-12 col-sm-12 col-md-6 col-md-offset-3">
   <form id="score" action="#" method="post" role="form">
+    <span class="commentbox-title">Your Review Comments</span>
+    <textarea name="comment" id="commentbox" class="form-control commentbox" rows="3"><%= abstract[:comment] %></textarea>
     <input class="col-xs-3 col-sm-8 col-md-6 col-lg-7" id="scoreSlider" data-slider-id="scoreSlider" type="text" data-slider-min="0" data-slider-max="10" data-slider-step="1" data-slider-value="<%= abstract[:score] || 0 %>"></input>
     <span class="saveScore">
       <div class="btn-group">
@@ -83,7 +85,7 @@
     $.ajax({
       accepts: {json: 'application/json'},
       cache: false,
-      data: { count: sliderValue },
+      data: { count: sliderValue, comment: $('textarea#commentbox').val() },
       dataType: 'json',
       type: 'POST',
       url: window.location.pathname + '/scores'

--- a/app/views/scores/index.erb
+++ b/app/views/scores/index.erb
@@ -53,6 +53,7 @@
       </span>
       <a href="/abstracts/<%= abstract.id %>"><%= abstract.title %></a><span class="author"> by <a href="mailto:<%= abstract[:email] %>"><%= abstract[:speaker] %></a></span><br>
       <% abstract[:scores].each do |review| %>
+        <% next if review[:comment].empty? %>
         <span class="comment"><strong><%= review[:judge] %>:</strong>  <%= review[:comment] %></span><br>
       <% end %>
     </li>

--- a/app/views/scores/index.erb
+++ b/app/views/scores/index.erb
@@ -51,7 +51,10 @@
           <% end %>
         <% end %>
       </span>
-      <a href="/abstracts/<%= abstract.id %>"><%= abstract.title %></a><span class="author"> by <a href="mailto:<%= abstract[:email] %>"><%= abstract[:speaker] %></a></span>
+      <a href="/abstracts/<%= abstract.id %>"><%= abstract.title %></a><span class="author"> by <a href="mailto:<%= abstract[:email] %>"><%= abstract[:speaker] %></a></span><br>
+      <% abstract[:scores].each do |review| %>
+        <span class="comment"><strong><%= review[:judge] %>:</strong>  <%= review[:comment] %></span><br>
+      <% end %>
     </li>
     <% end %>
   </ul>


### PR DESCRIPTION
This adds support for reviewer comments (#14). Reviews now have a field for adding a comment along with the scoring. It looks something like this:
![judycomment](https://cloud.githubusercontent.com/assets/2254952/14934302/d250562a-0e7a-11e6-8fb2-635d63ed6d6f.png)

To give the best at an untainted submission review, I moved the list of comments to the "scores" page:
![clist](https://cloud.githubusercontent.com/assets/2254952/14934379/346e5aa4-0e7c-11e6-8d6c-2a5fe8df7b0c.png).