### PR TITLE
Add in 'accepted' flag

### DIFF
--- a/app/controllers/abstracts.rb
+++ b/app/controllers/abstracts.rb
@@ -78,7 +78,7 @@ module Judy
         raise "User is not an admin" unless user_is_admin?
         content_type 'application/json'
         @abstract = Abstract[params[:id]]
-        %w[title body].each do |attr|
+        %w[title body accepted].each do |attr|
           @abstract.update(attr.to_sym => params[attr]) if !params[attr].nil?
         end
         @abstract.save

--- a/app/migrations/005_AddAcceptedToAbstract.rb
+++ b/app/migrations/005_AddAcceptedToAbstract.rb
@@ -1,0 +1,8 @@
+
+Sequel.migration do
+  up do
+    alter_table(:abstracts) do
+      add_column :accepted, Integer
+    end
+  end
+end

--- a/app/public/css/style.css
+++ b/app/public/css/style.css
@@ -141,6 +141,33 @@ div.abstract {
   margin-top: 10px;
 }
 
+.label-accepted {
+  display: inline;
+  border-style: solid;
+  border
+  border-color: #5cb85c;
+  padding: .2em .6em .3em;
+  font-size: 75%;
+  line-height: 1;
+  color: #5cb85c;
+  text-align: center;
+  white-space: nowrap;
+  vertical-align: baseline;
+  border-radius: .25em;
+  background-color: #ffffff;
+}
+
+ul.abstracts li span.score-accept {
+  display: inline-block;
+  min-width: 50px;
+  margin-right: 10px;
+  background: #5cb85c;
+  border-radius: 15px;
+  font-family: sans-serif;
+  text-align: center;
+  color: #fff;
+}
+
 .slider-selection {
   background: #ccc;
 }

--- a/app/views/abstracts/show.erb
+++ b/app/views/abstracts/show.erb
@@ -23,7 +23,8 @@
 
 <div class="abstract col-xs-12 col-md-6 col-md-offset-3">
   <h1 id="title"><%= abstract.title.gsub(/: /, ':<br />') %></h1>
-  <h4 id="label"><span class="label label-<%= label %>"><%= abstract.type %></span></h4>
+  <h4 id="label"><span class="label label-<%= label %>"><%= abstract.type %></span>
+  <% if user_is_admin? && abstract.accepted == 1 %><span class="label label-accepted">accepted</span><% end %></h4>
   <div id="body">
     <%= abstract.body.gsub(/\n/, '<br />').gsub(/\r\n\r/, '<br /><br />') %>
   </div>
@@ -59,6 +60,7 @@
         <ul class="dropdown-menu" role="menu">
           <li><a id="skip" href="#">Skip</a></li>
           <% if user_is_admin? %>
+          <li><a id="acceptAbstract" href="#">Toggle Acceptance</a></li>
           <li><a id="edit" href="#">Edit</a></li>
           <li><a id="delete" href="#" data-toggle="modal" data-target="#deleteAbstract">Delete</a></li>
           <% end %>
@@ -136,7 +138,35 @@
   });
   <% end %>
 </script>
- 
+
+<!-- Accept abstract handler -->
+<script type="text/javascript">
+  <% if user_is_admin? %>
+  <% if abstract.accepted == 1 %>
+  var acceptVar = null
+  <% else %>
+  var acceptVar = 1
+  <% end %>
+
+  $('a#acceptAbstract').on('click', function() {
+    return $.ajax({
+      accepts: {json: 'application/json'},
+      cache: false,
+      data: {accepted: acceptVar},
+      dataType: 'json',
+      error: function(xhr, textStatus, errorThrown) { console.log(errorThrown); },
+      type: 'PUT',
+      url: window.location.pathname
+    }).success(function(d) {
+      console.log("successfully accepted abstract");
+      window.location = window.location.pathname;
+    }).fail(function(d) {
+      console.log(d.responseText);
+    });
+  });
+  <% end %>
+</script>
+
 <!-- Delete abstract handler -->
 <script type="text/javascript">
   <% if user_is_admin? %>

--- a/app/views/scores/index.erb
+++ b/app/views/scores/index.erb
@@ -41,7 +41,11 @@
   <ul class="abstracts">
     <% @abstracts.each do |abstract| %>
     <li class="<%= abstract.type %>">
+      <% if user_is_admin? && abstract.accepted == 1 %>
+      <span class="score-accept">
+      <% else %>
       <span class="score">
+      <% end %>
         <% sort_type = "#{@sort}_score".to_sym %>
         <% if ! abstract[sort_type].nil? %>
           <% if @sort.eql?('mode') %>


### PR DESCRIPTION
Not sure if this would be useful to you but figured I'd send it your way: sometimes it's nice to be able to mark talks as accepted so you know. This will add an "accepted" label next to the session type in abstracts#show, and will turn the score background green in scores#index

If this isn't useful for your workflow, no big - just thought I'd share.