### PR TITLE
Support for email receipt of abstract submission

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'http://rubygems.org'
 
-ruby '1.9.3'
+ruby '2.2.7'
 
 gem 'rake'
 gem 'sinatra'

--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,6 @@ gem 'pry'
 # lock in mime-types < 3.0 since it pulls
 # in mime-types-data > 3.x requiring Ruby 2.x
 gem 'mime-types', '< 3.0'
-gem 'mail'
 gem 'postmark'
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,13 @@ gem 'rack-flash3'
 gem 'json'
 gem 'pry'
 
+# the following is for the postmark addon
+# lock in mime-types < 3.0 since it pulls
+# in mime-types-data > 3.x requiring Ruby 2.x
+gem 'mime-types', '< 3.0'
+gem 'mail'
+gem 'postmark'
+
 group :development do
   gem 'rack-test'
   gem 'rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,8 +6,6 @@ GEM
     diff-lcs (1.2.5)
     eventmachine (1.0.4)
     json (1.8.1)
-    mail (2.6.3)
-      mime-types (>= 1.16, < 3)
     method_source (0.8.2)
     mime-types (1.25.1)
     pg (0.17.1)
@@ -54,7 +52,6 @@ PLATFORMS
 
 DEPENDENCIES
   json
-  mail
   mime-types (< 3.0)
   pg
   postmark

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,8 +6,14 @@ GEM
     diff-lcs (1.2.5)
     eventmachine (1.0.3)
     json (1.8.1)
+    mail (2.6.3)
+      mime-types (>= 1.16, < 3)
     method_source (0.8.2)
+    mime-types (1.25.1)
     pg (0.17.1)
+    postmark (1.10.0)
+      json
+      rake
     pry (0.9.12.6)
       coderay (~> 1.0)
       method_source (~> 0.8)
@@ -48,7 +54,10 @@ PLATFORMS
 
 DEPENDENCIES
   json
+  mail
+  mime-types (< 3.0)
   pg
+  postmark
   pry
   rack-flash3
   rack-ssl-enforcer
@@ -60,3 +69,6 @@ DEPENDENCIES
   sinatra
   sinatra-cross_origin
   thin
+
+BUNDLED WITH
+   1.11.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ GEM
     coderay (1.1.0)
     daemons (1.1.9)
     diff-lcs (1.2.5)
-    eventmachine (1.0.3)
+    eventmachine (1.0.4)
     json (1.8.1)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
@@ -70,5 +70,8 @@ DEPENDENCIES
   sinatra-cross_origin
   thin
 
+RUBY VERSION
+   ruby 2.2.7p470
+
 BUNDLED WITH
-   1.11.2
+   1.14.6

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Judy's design goals are straightforward:
 * Interpreting the results should be simple.
 * The interface should fulfill all of the above requirements, particularly on mobile devices, with as few clicks as possible.
 
-Judy has already helped us to review seventy-eight (78) submissions for the upcoming Monitorama PDX conference in record time. It enabled us to bring in a larger team of volunteers to review and judge papers than would have previously been possible, increasing diversity and helping to float the very best talks to the top of the stack.
+Judy has helped numerous users review thousands of submissions for a variety of events. For our own events, it enabled us to bring in a larger team of volunteers to review and judge papers than would have previously been possible, increasing diversity and helping to float the very best talks to the top of the stack.
 
 ## Deployment
 
@@ -43,6 +43,9 @@ All environment variables can be set from the command-line, although it's sugges
 * `JUDY_AUTH` (required)
 * `JUDY_ADMIN` (optional)
 * `FORCE_HTTPS` (optional)
+* `POSTMARK_API_TOKEN` (optional)
+* `POSTMARK_TEMPLATE_ID` (optional)
+* `MAIL_FROM_ADDRESS` (optional)
 
 ### Authorization
 
@@ -59,6 +62,27 @@ JUDY_ADMIN=user1,user3
 ```
 
 Administrators are able to *edit* and *delete* abstracts from the abstract view.
+
+### Submission Acknowledgement via Email
+
+Judy supports email acknowledgement of abstract submission via the Postmark email delivery API. This feature is an optional but helpful way to notify prospective speakers that their form submission was received. This feature makes use of Postmark's [Templates](https://postmarkapp.com/support/article/786-using-a-postmark-starter-template) feature. You should include a variable for the abstract `title`; currently this is the only variable passed through Postmark's `template_model`.
+
+```
+Thank you for your submission!
+
+Title: {{ title }}
+
+Best wishes,
+The Event Organizers
+```
+
+The related environment variables must be set for this feature to be enabled. If any of these variables are unset, email acknowledgement will not be attempted.
+
+```
+POSTMARK_API_TOKEN=12345678-abcd-1234-5678-abcd12345678
+POSTMARK_TEMPLATE_ID=1234567
+MAIL_FROM_ADDRESS=Event 2018 <foo@bar.com>
+```
 
 ### Local
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Best wishes,
 The Event Organizers
 ```
 
-The related environment variables must be set for this feature to be enabled. If any of these variables are unset, email acknowledgement will not be attempted.
+The related environment variables must be set for this feature to be enabled. If any of these variables are unset, email acknowledgement will not be attempted. Note that you will almost certainly want to create a Postmark Sender Signature to match your `MAIL_FROM_ADDRESS`.
 
 ```
 POSTMARK_API_TOKEN=12345678-abcd-1234-5678-abcd12345678

--- a/app/app.rb
+++ b/app/app.rb
@@ -3,6 +3,8 @@ require 'sinatra/cross_origin'
 require 'rack-ssl-enforcer'
 require 'rack-flash'
 require 'json'
+require 'mail'
+require 'postmark'
 
 require 'models/init'
 

--- a/app/app.rb
+++ b/app/app.rb
@@ -3,7 +3,6 @@ require 'sinatra/cross_origin'
 require 'rack-ssl-enforcer'
 require 'rack-flash'
 require 'json'
-require 'mail'
 require 'postmark'
 
 require 'models/init'

--- a/app/controllers/abstracts.rb
+++ b/app/controllers/abstracts.rb
@@ -54,6 +54,7 @@ module Judy
           :type => params[:type],
           :speaker_id => @speaker.id,
           :event_id => 1).save
+        mail_cfp_acknowledgement("#{@speaker.full_name} <#{@speaker.email}>")
         status 200
         erb :'abstracts/new', :locals => { :alert => { :type => 'success', :message => 'Abstract successfully added' } }
       rescue => e

--- a/app/controllers/abstracts.rb
+++ b/app/controllers/abstracts.rb
@@ -54,7 +54,7 @@ module Judy
           :type => params[:type],
           :speaker_id => @speaker.id,
           :event_id => 1).save
-        mail_cfp_acknowledgement("#{@speaker.full_name} <#{@speaker.email}>")
+        mail_cfp_acknowledgement(:recipient => "#{@speaker.full_name} <#{@speaker.email}>", :title => @abstract.title)
         status 200
         erb :'abstracts/new', :locals => { :alert => { :type => 'success', :message => 'Abstract successfully added' } }
       rescue => e

--- a/app/controllers/abstracts.rb
+++ b/app/controllers/abstracts.rb
@@ -56,6 +56,7 @@ module Judy
           :event_id => 1).save
         if mail_cfp_acknowledgement?
           mail_cfp_acknowledgement(:recipient => "#{@speaker.full_name} <#{@speaker.email}>", :title => @abstract.title)
+        end
         status 200
         erb :'abstracts/new', :locals => { :alert => { :type => 'success', :message => 'Abstract successfully added' } }
       rescue => e

--- a/app/controllers/abstracts.rb
+++ b/app/controllers/abstracts.rb
@@ -47,7 +47,7 @@ module Judy
     post '/abstracts/new/?' do
       cross_origin
       begin
-        @speaker = Speaker.new(:full_name => params[:full_name], :email => params[:email]).save
+        @speaker = Speaker.new(:full_name => params[:full_name], :email => params[:email], :twitter => params[:twitter], :github => params[:github]).save
         @abstract = Abstract.new(
           :title => params[:title],
           :body => params[:body],

--- a/app/controllers/abstracts.rb
+++ b/app/controllers/abstracts.rb
@@ -54,7 +54,8 @@ module Judy
           :type => params[:type],
           :speaker_id => @speaker.id,
           :event_id => 1).save
-        mail_cfp_acknowledgement(:recipient => "#{@speaker.full_name} <#{@speaker.email}>", :title => @abstract.title)
+        if mail_cfp_acknowledgement?
+          mail_cfp_acknowledgement(:recipient => "#{@speaker.full_name} <#{@speaker.email}>", :title => @abstract.title)
         status 200
         erb :'abstracts/new', :locals => { :alert => { :type => 'success', :message => 'Abstract successfully added' } }
       rescue => e

--- a/app/controllers/helpers.rb
+++ b/app/controllers/helpers.rb
@@ -52,31 +52,20 @@ module Judy
       end
 
       # Mail helpers
+      def send_mail_acknowledgement?
+        !ENV['POSTMARK_API_TOKEN'].nil? && !ENV['MAIL_FROM_ADDRESS'].nil? && !ENV['POSTMARK_TEMPLATE_ID'].nil?
+      end
       def mail_cfp_acknowledgement(args)
-        message = Mail.new do
-          to      args[:recipient]
-          from    'Monitorama PDX 2017 <info@monitorama.com>'
-          subject 'Monitorama PDX 2017 - CFP Submission Received'
-          body    <<-EOS
-Greetings!\n
-On behalf of the Monitorama team, I want to personally thank you for
-submitting your proposal for our upcoming event. Your abstract has been
-successfully recorded, and we expect to review it in the coming weeks.
-We should finish our deliberations by Feb 15, 2017, and we will send out
-notifications shortly thereafter.\n
-Title: "#{args[:title]}"\n
-Please note that you're allowed, nay, *encouraged*, to submit multiple
-proposals. We're very excited to see what sort of proposals come in this
-year. Regardless of the outcome, we hope that you're making plans to
-join us in Portland for this event.\n
-Best wishes,\n
-Jason Dixon
-Monitorama PDX 2017
-EOS
-
-          delivery_method Mail::Postmark, :api_token => ENV['POSTMARK_API_TOKEN']
-        end
-        message.deliver
+        client = Postmark::ApiClient.new(ENV['POSTMARK_API_TOKEN'])
+        client.deliver(
+          track_opens: true,
+          from: ENV['MAIL_FROM_ADDRESS'],
+          to: args[:recipient],
+          template_id: ENV['POSTMARK_TEMPLATE_ID'],
+          template_model: {
+            title: args[:title]
+          }
+        )
       end
     end
   end

--- a/app/controllers/helpers.rb
+++ b/app/controllers/helpers.rb
@@ -64,7 +64,7 @@ submitting your proposal for our upcoming event. Your abstract has been
 successfully recorded, and we expect to review it in the coming weeks.
 We should finish our deliberations by Feb 15, 2017, and we will send out
 notifications shortly thereafter.\n
-Title: #{args[:title]}\n
+Title: "#{args[:title]}"\n
 Please note that you're allowed, nay, *encouraged*, to submit multiple
 proposals. We're very excited to see what sort of proposals come in this
 year. Regardless of the outcome, we hope that you're making plans to

--- a/app/controllers/helpers.rb
+++ b/app/controllers/helpers.rb
@@ -58,20 +58,20 @@ module Judy
           from    'Monitorama PDX 2017 <info@monitorama.com>'
           subject 'Monitorama PDX 2017 - CFP Submission Received'
           body    <<-EOS
-                  Greetings!\n\n
-                  On behalf of the Monitorama team, I want to personally thank you for
-                  submitting your proposal for our upcoming event. Your abstract has been
-                  successfully recorded, and we expect to review it in the coming weeks.
-                  We should finish our deliberations by Feb 15, 2017, and we will send out
-                  notifications shortly thereafter.\n\n
-                  Please note that you're allowed, nay, *encouraged*, to submit multiple
-                  proposals. We're very excited to see what sort of proposals come in this
-                  year. Regardless of the outcome, we hope that you're making plans to
-                  join us in Portland for this event.\n\n
-                  Best wishes,\n\n
-                  Jason Dixon\n
-                  Monitorama PDX 2017
-                  EOS
+Greetings!\n
+On behalf of the Monitorama team, I want to personally thank you for
+submitting your proposal for our upcoming event. Your abstract has been
+successfully recorded, and we expect to review it in the coming weeks.
+We should finish our deliberations by Feb 15, 2017, and we will send out
+notifications shortly thereafter.\n
+Please note that you're allowed, nay, *encouraged*, to submit multiple
+proposals. We're very excited to see what sort of proposals come in this
+year. Regardless of the outcome, we hope that you're making plans to
+join us in Portland for this event.\n
+Best wishes,\n
+Jason Dixon
+Monitorama PDX 2017
+EOS
 
           delivery_method Mail::Postmark, :api_token => ENV['POSTMARK_API_TOKEN']
         end

--- a/app/controllers/helpers.rb
+++ b/app/controllers/helpers.rb
@@ -50,6 +50,19 @@ module Judy
       def dataset_score_distribution
         return Score.all.reduce([]) {|a,score| a[score.count] ||= 0; a[score.count] += 1; a}.map {|c| c.to_i}.join(',')
       end
+
+      # Mail helpers
+      def mail_cfp_acknowledgement(recipient)
+        message = Mail.new do
+          to      recipient
+          from    'Monitorama PDX 2017 <info@monitorama.com>'
+          subject 'Monitorama PDX 2017 - CFP Submission Received'
+          body    'Thank You'
+
+          delivery_method Mail::Postmark, :api_token => ENV['POSTMARK_API_TOKEN']
+        end
+        message.deliver
+      end
     end
   end
 end

--- a/app/controllers/helpers.rb
+++ b/app/controllers/helpers.rb
@@ -57,7 +57,7 @@ module Judy
       end
       def mail_cfp_acknowledgement(args)
         client = Postmark::ApiClient.new(ENV['POSTMARK_API_TOKEN'])
-        client.deliver(
+        client.deliver_with_template(
           track_opens: true,
           from: ENV['MAIL_FROM_ADDRESS'],
           to: args[:recipient],

--- a/app/controllers/helpers.rb
+++ b/app/controllers/helpers.rb
@@ -52,9 +52,9 @@ module Judy
       end
 
       # Mail helpers
-      def mail_cfp_acknowledgement(recipient)
+      def mail_cfp_acknowledgement(args)
         message = Mail.new do
-          to      recipient
+          to      args[:recipient]
           from    'Monitorama PDX 2017 <info@monitorama.com>'
           subject 'Monitorama PDX 2017 - CFP Submission Received'
           body    <<-EOS
@@ -64,6 +64,7 @@ submitting your proposal for our upcoming event. Your abstract has been
 successfully recorded, and we expect to review it in the coming weeks.
 We should finish our deliberations by Feb 15, 2017, and we will send out
 notifications shortly thereafter.\n
+Title: #{args[:title]}\n
 Please note that you're allowed, nay, *encouraged*, to submit multiple
 proposals. We're very excited to see what sort of proposals come in this
 year. Regardless of the outcome, we hope that you're making plans to

--- a/app/controllers/helpers.rb
+++ b/app/controllers/helpers.rb
@@ -52,27 +52,26 @@ module Judy
       end
 
       # Mail helpers
-      def mail_body
-        "Greetings!\n\n
-        On behalf of the Monitorama team, I want to personally thank you for
-        submitting your proposal for our upcoming event. Your abstract has been
-        successfully recorded, and we expect to review it in the coming weeks.
-        We should finish our deliberations by Feb 15, 2017, and we will send out
-        notifications shortly thereafter.\n\n
-        Please note that you're allowed, nay, *encouraged*, to submit multiple
-        proposals. We're very excited to see what sort of proposals come in this
-        year. Regardless of the outcome, we hope that you're making plans to
-        join us in Portland for this event.\n\n
-        Best wishes,\n\n
-        Jason Dixon\n
-        Monitorama PDX 2017"
-      end
       def mail_cfp_acknowledgement(recipient)
         message = Mail.new do
           to      recipient
           from    'Monitorama PDX 2017 <info@monitorama.com>'
           subject 'Monitorama PDX 2017 - CFP Submission Received'
-          body    mail_body
+          body    <<-EOS
+                  Greetings!\n\n
+                  On behalf of the Monitorama team, I want to personally thank you for
+                  submitting your proposal for our upcoming event. Your abstract has been
+                  successfully recorded, and we expect to review it in the coming weeks.
+                  We should finish our deliberations by Feb 15, 2017, and we will send out
+                  notifications shortly thereafter.\n\n
+                  Please note that you're allowed, nay, *encouraged*, to submit multiple
+                  proposals. We're very excited to see what sort of proposals come in this
+                  year. Regardless of the outcome, we hope that you're making plans to
+                  join us in Portland for this event.\n\n
+                  Best wishes,\n\n
+                  Jason Dixon\n
+                  Monitorama PDX 2017
+                  EOS
 
           delivery_method Mail::Postmark, :api_token => ENV['POSTMARK_API_TOKEN']
         end

--- a/app/controllers/helpers.rb
+++ b/app/controllers/helpers.rb
@@ -52,7 +52,7 @@ module Judy
       end
 
       # Mail helpers
-      def send_mail_acknowledgement?
+      def mail_cfp_acknowledgement?
         !ENV['POSTMARK_API_TOKEN'].nil? && !ENV['MAIL_FROM_ADDRESS'].nil? && !ENV['POSTMARK_TEMPLATE_ID'].nil?
       end
       def mail_cfp_acknowledgement(args)

--- a/app/controllers/helpers.rb
+++ b/app/controllers/helpers.rb
@@ -52,12 +52,27 @@ module Judy
       end
 
       # Mail helpers
+      def mail_body
+        "Greetings!\n\n
+        On behalf of the Monitorama team, I want to personally thank you for
+        submitting your proposal for our upcoming event. Your abstract has been
+        successfully recorded, and we expect to review it in the coming weeks.
+        We should finish our deliberations by Feb 15, 2017, and we will send out
+        notifications shortly thereafter.\n\n
+        Please note that you're allowed, nay, *encouraged*, to submit multiple
+        proposals. We're very excited to see what sort of proposals come in this
+        year. Regardless of the outcome, we hope that you're making plans to
+        join us in Portland for this event.\n\n
+        Best wishes,\n\n
+        Jason Dixon\n
+        Monitorama PDX 2017"
+      end
       def mail_cfp_acknowledgement(recipient)
         message = Mail.new do
           to      recipient
           from    'Monitorama PDX 2017 <info@monitorama.com>'
           subject 'Monitorama PDX 2017 - CFP Submission Received'
-          body    'Thank You'
+          body    mail_body
 
           delivery_method Mail::Postmark, :api_token => ENV['POSTMARK_API_TOKEN']
         end

--- a/app/public/css/style.css
+++ b/app/public/css/style.css
@@ -209,9 +209,3 @@ div.progress {
 div.footer {
   min-height: 150px;
 }
-
-// stop google chrome from showing urls when printing
-@media print {
-  a:after { content:''; }
-  a[href]:after { content: none !important; }
-}

--- a/app/public/css/style.css
+++ b/app/public/css/style.css
@@ -209,3 +209,9 @@ div.progress {
 div.footer {
   min-height: 150px;
 }
+
+// stop google chrome from showing urls when printing
+@media print {
+  a:after { content:''; }
+  a[href]:after { content: none !important; }
+}


### PR DESCRIPTION
This adds the ability to send notification emails to CFP submitters via the Postmark sender API. Earlier commits within this branch were effectively a WIP that I used for an event last year. This earlier PoC has been refactored recently to take advantage of environment variables and Postmark's templating functionality.