### PR TITLE
Add JUDY_CHAIR role

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ All environment variables can be set from the command-line, although it's sugges
 * `DATABASE_URL` (required)
 * `JUDY_AUTH` (required)
 * `JUDY_ADMIN` (optional)
+* `JUDY_CHAIR` (optional)
 * `FORCE_HTTPS` (optional)
 * `POSTMARK_API_TOKEN` (optional)
 * `POSTMARK_TEMPLATE_ID` (optional)
@@ -62,6 +63,12 @@ JUDY_ADMIN=user1,user3
 ```
 
 Administrators are able to *edit* and *delete* abstracts from the abstract view.
+
+Users listed in the `JUDY_CHAIR` environment variable have access to per-reviewer scores and comments on the scores page. Any users already specified in `JUDY_ADMIN` inherit this functionality.
+
+```
+JUDY_CHAIR=user2
+```
 
 ### Submission Acknowledgement via Email
 

--- a/app.json
+++ b/app.json
@@ -22,6 +22,11 @@
       "value": "user,user3",
       "required": false
     },
+    "JUDY_CHAIR": {
+      "description": "Users (names from JUDY_AUTH) that are allowed to view score details and comments",
+      "value": "user,user3",
+      "required": false
+    },
     "FORCE_HTTPS": {
         "description": "Always use HTTPS (you probably don't want to change this)",
         "value": "true",

--- a/app/controllers/helpers.rb
+++ b/app/controllers/helpers.rb
@@ -34,6 +34,13 @@ module Judy
         end
         return false
       end
+      def user_is_chair?
+	user_is_admin?
+        ENV['JUDY_CHAIR'].split(',').each do |chair|
+	  return true if chair.eql?(@auth.credentials.first)
+        end
+        return false
+      end
       def judges
         ENV['JUDY_AUTH'].split(',').each.map {|a| a.split(':').first}
       end

--- a/app/controllers/helpers.rb
+++ b/app/controllers/helpers.rb
@@ -35,7 +35,7 @@ module Judy
         return false
       end
       def user_is_chair?
-	user_is_admin?
+	return true if user_is_admin?
         ENV['JUDY_CHAIR'].split(',').each do |chair|
 	  return true if chair.eql?(@auth.credentials.first)
         end

--- a/app/public/css/style.css
+++ b/app/public/css/style.css
@@ -80,7 +80,6 @@ ul.abstracts li span.score {
 }
 
 ul.abstracts li span.count {
-  visibility: hidden;
   display: inline-block;
   min-width: 25px;
   margin-left: 65px;

--- a/app/public/css/style.css
+++ b/app/public/css/style.css
@@ -82,8 +82,8 @@ ul.abstracts li span.score {
 ul.abstracts li span.count {
   visibility: hidden;
   display: inline-block;
-  min-width: 40px;
-  margin-right: 8px;
+  min-width: 25px;
+  margin-left: 65px;
   background: #bbb;
   border-radius: 12px;
   font-family: sans-serif;
@@ -92,7 +92,7 @@ ul.abstracts li span.count {
 }
 
 ul.abstracts li span.comment {
-  margin-left: 65px;
+  margin-left: 8px;
 }
 
 ul.abstracts li a, ul.events li a {

--- a/app/public/css/style.css
+++ b/app/public/css/style.css
@@ -84,6 +84,7 @@ ul.abstracts li span.count {
   display: inline-block;
   min-width: 25px;
   margin-left: 65px;
+  margin-bottom: 3px;
   background: #bbb;
   border-radius: 12px;
   font-family: sans-serif;

--- a/app/public/css/style.css
+++ b/app/public/css/style.css
@@ -79,6 +79,18 @@ ul.abstracts li span.score {
   color: #fff;
 }
 
+ul.abstracts li span.count {
+  visibility: hidden;
+  display: inline-block;
+  min-width: 40px;
+  margin-right: 8px;
+  background: #bbb;
+  border-radius: 12px;
+  font-family: sans-serif;
+  text-align: center;
+  color: #fff;
+}
+
 ul.abstracts li span.comment {
   margin-left: 65px;
 }

--- a/app/views/scores/index.erb
+++ b/app/views/scores/index.erb
@@ -52,8 +52,10 @@
         <% end %>
       </span>
       <a href="/abstracts/<%= abstract.id %>"><%= abstract.title %></a><span class="author"> by <a href="mailto:<%= abstract[:email] %>"><%= abstract[:speaker] %></a></span><br>
-      <% abstract[:scores].each do |review| %>
-	<span class="count"><%= review[:count] %></span><span class="comment"><strong><%= review[:judge] %>:</strong>  <%= review[:comment] %></span><br>
+      <% if user_is_chair? %>
+        <% abstract[:scores].each do |review| %>
+          <span class="count"><%= review[:count] %></span><span class="comment"><strong><%= review[:judge] %>:</strong>  <%= review[:comment] %></span><br>
+        <% end %>
       <% end %>
     </li>
     <% end %>

--- a/app/views/scores/index.erb
+++ b/app/views/scores/index.erb
@@ -54,7 +54,7 @@
       <a href="/abstracts/<%= abstract.id %>"><%= abstract.title %></a><span class="author"> by <a href="mailto:<%= abstract[:email] %>"><%= abstract[:speaker] %></a></span><br>
       <% abstract[:scores].each do |review| %>
         <% next if review[:comment].empty? %>
-        <span class="comment"><strong><%= review[:judge] %>:</strong>  <%= review[:comment] %></span><br>
+	<span class="count"><%= review[:count] %></span><span class="comment"><strong><%= review[:judge] %>:</strong>  <%= review[:comment] %></span><br>
       <% end %>
     </li>
     <% end %>

--- a/app/views/scores/index.erb
+++ b/app/views/scores/index.erb
@@ -53,7 +53,6 @@
       </span>
       <a href="/abstracts/<%= abstract.id %>"><%= abstract.title %></a><span class="author"> by <a href="mailto:<%= abstract[:email] %>"><%= abstract[:speaker] %></a></span><br>
       <% abstract[:scores].each do |review| %>
-        <% next if review[:comment].empty? %>
 	<span class="count"><%= review[:count] %></span><span class="comment"><strong><%= review[:judge] %>:</strong>  <%= review[:comment] %></span><br>
       <% end %>
     </li>


### PR DESCRIPTION
This change introduces the `JUDY_CHAIR` role, which allows us to limit visibility of per-reviewer comments and scores on the Scores page to a subset of `JUDY_AUTH` users. Naturally, this means we're also surfacing this new level of detail in the UI.

![2019-02-19 09_56_17-judy](https://user-images.githubusercontent.com/494338/53024389-f11e2200-342c-11e9-91d0-6d951fdbc8c7.png)
