### PR TITLE
Restore reviewer comments for non-chair view

### DIFF
--- a/app/controllers/scores.rb
+++ b/app/controllers/scores.rb
@@ -6,7 +6,7 @@ module Judy
       @sort = params[:sort] || 'mean'
       @abstracts = Abstract.fetch_all_abstracts_and_scores(:sort => @sort)
       status 200
-      erb :'scores/index', :locals => { :abstracts => @abstracts, :sort => @sort }
+      erb :'scores/index', :locals => { :abstracts => @abstracts, :sort => @sort, :user => session[:user] }
     end
   end
 end

--- a/app/public/css/style.css
+++ b/app/public/css/style.css
@@ -72,6 +72,7 @@ ul.abstracts li span.score {
   display: inline-block;
   min-width: 50px;
   margin-right: 10px;
+  margin-bottom: 5px;
   background: #bbb;
   border-radius: 15px;
   font-family: sans-serif;

--- a/app/public/css/style.css
+++ b/app/public/css/style.css
@@ -92,7 +92,7 @@ ul.abstracts li span.count {
 }
 
 ul.abstracts li span.comment {
-  margin-left: 8px;
+  margin-left: 10px;
 }
 
 ul.abstracts li a, ul.events li a {

--- a/app/views/scores/index.erb
+++ b/app/views/scores/index.erb
@@ -52,8 +52,8 @@
         <% end %>
       </span>
       <a href="/abstracts/<%= abstract.id %>"><%= abstract.title %></a><span class="author"> by <a href="mailto:<%= abstract[:email] %>"><%= abstract[:speaker] %></a></span><br>
-      <% if user_is_chair? %>
-        <% abstract[:scores].each do |review| %>
+      <% abstract[:scores].each do |review| %>
+        <% if user_is_chair? || user.eql?(review[:judge]) %>
           <span class="count"><%= review[:count] %></span><span class="comment"><strong><%= review[:judge] %>:</strong>  <%= review[:comment] %></span><br>
         <% end %>
       <% end %>

--- a/app/views/scores/index.erb
+++ b/app/views/scores/index.erb
@@ -53,8 +53,10 @@
       </span>
       <a href="/abstracts/<%= abstract.id %>"><%= abstract.title %></a><span class="author"> by <a href="mailto:<%= abstract[:email] %>"><%= abstract[:speaker] %></a></span><br>
       <% abstract[:scores].each do |review| %>
-        <% if user_is_chair? || user.eql?(review[:judge]) %>
+        <% if user_is_chair? %>
           <span class="count"><%= review[:count] %></span><span class="comment"><strong><%= review[:judge] %>:</strong>  <%= review[:comment] %></span><br>
+        <% elsif user.eql?(review[:judge]) %>
+          <span class="count"><%= review[:count] %></span><span class="comment"><%= review[:comment] %></span><br>
         <% end %>
       <% end %>
     </li>


### PR DESCRIPTION
The previous changeset (#34) reverted a non-chair reviewer's ability to see their own scores and comments. This change restores that behavior with some slight visual tweaks.